### PR TITLE
Added missing example files; added missing credentials example files.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,4 @@ src/*.pb.h
 # Secrets
 src/client/configs/*
 **/*credentials*
+!**/*credentials*.example

--- a/examples/RFQuack-huzzah-rf69hw/Makefile
+++ b/examples/RFQuack-huzzah-rf69hw/Makefile
@@ -1,0 +1,26 @@
+SHELL := /bin/bash
+
+all: build
+
+build:
+	pio -f -c vim run
+
+upload:
+	pio -f -c vim run --target upload
+
+clean:
+	pio -f -c vim run --target clean
+
+program:
+	pio -f -c vim run --target program
+
+uploadfs:
+	pio -f -c vim run --target uploadfs
+
+update:
+	pio -f -c vim update
+
+monitor:
+	pio -f -c vim device monitor
+
+.PHONY: all

--- a/examples/RFQuack-huzzah-rf69hw/README.md
+++ b/examples/RFQuack-huzzah-rf69hw/README.md
@@ -1,0 +1,1 @@
+# RFQuack-huzzah-rf69hw

--- a/examples/RFQuack-huzzah-rf69hw/platformio.ini
+++ b/examples/RFQuack-huzzah-rf69hw/platformio.ini
@@ -1,0 +1,17 @@
+; PlatformIO Project Configuration File
+;
+;   Build options: build flags, source filter
+;   Upload options: custom upload port, speed and extra flags
+;   Library options: dependencies, extra library storages
+;   Advanced options: extra scripting
+;
+; Please visit documentation for the other options and examples
+; https://docs.platformio.org/page/projectconf.html
+
+[env:huzzah]
+platform = espressif8266
+board = huzzah
+framework = arduino
+upload_port = /dev/cu.SLAB_USBtoUART*
+upload_speed = 115200
+monitor_speed = 115200

--- a/examples/RFQuack-huzzah-rf69hw/src/main.cpp
+++ b/examples/RFQuack-huzzah-rf69hw/src/main.cpp
@@ -1,0 +1,39 @@
+/*****************************************************************************
+ * RFQuack configuration/
+ *****************************************************************************/
+
+/* ID definition */
+#define RFQUACK_UNIQ_ID "HUZZAH_RF69HW"
+
+/* Network configuration */
+#define RFQUACK_NETWORK_ESP8266
+#include "wifi_credentials.h" // <- not committed because it contains secrets
+
+/* Transport configuration */
+#define RFQUACK_TRANSPORT_MQTT
+#define RFQUACK_MQTT_BROKER_HOST "192.168.43.116"
+#define RFQUACK_MQTT_BROKER_PORT 1883
+
+/* Radio configuration */
+#define RFQUACK_RADIO_RF69
+#define RFQUACK_RADIO_HIGHPOWER 1 // for RF69HCW (note the "H")
+
+#define RFQUACK_RADIO_PIN_CS 2
+#define RFQUACK_RADIO_PIN_RST 16
+#define RFQUACK_RADIO_PIN_IRQ 15
+
+
+/* Enable RadioHAL debug messages */
+#define RFQUACK_DEBUG_RADIO true
+#define RFQUACK_DEV
+
+#define RFQUACK_LOG_SS_DISABLED
+
+/*****************************************************************************
+ * /RFQuack configuration - DO NOT EDIT BELOW THIS LINE
+ *****************************************************************************/
+
+#include "rfquack.h"
+
+void setup() { rfquack_setup(); }
+void loop() { rfquack_loop(); }

--- a/examples/RFQuack-huzzah-rf69hw/src/wifi_credentials.h.example
+++ b/examples/RFQuack-huzzah-rf69hw/src/wifi_credentials.h.example
@@ -1,0 +1,5 @@
+# Set here the credential for your wifi network
+# Rename this file to "wifi_credentials.h"
+
+#define RFQUACK_NETWORK_SSID ""
+#define RFQUACK_NETWORK_PASS ""

--- a/examples/RFQuack-wemosd1-cc1120/src/wifi_credentials.h.example
+++ b/examples/RFQuack-wemosd1-cc1120/src/wifi_credentials.h.example
@@ -1,0 +1,5 @@
+# Set here the credential for your wifi network
+# Rename this file to "wifi_credentials.h"
+
+#define RFQUACK_NETWORK_SSID ""
+#define RFQUACK_NETWORK_PASS ""

--- a/examples/RFQuack-wemosd1-rf69hcw/src/wifi_credentials.h.example
+++ b/examples/RFQuack-wemosd1-rf69hcw/src/wifi_credentials.h.example
@@ -1,0 +1,5 @@
+# Set here the credential for your wifi network
+# Rename this file to "wifi_credentials.h"
+
+#define RFQUACK_NETWORK_SSID ""
+#define RFQUACK_NETWORK_PASS ""


### PR DESCRIPTION
Added missing configuration example for RFQuack-huzzah-rf69hw
Added example for credentials file
Updated .gitignore to track example configuration for scret files (*credentials*.example)